### PR TITLE
Support for iOS8

### DIFF
--- a/MomentsGallery.podspec
+++ b/MomentsGallery.podspec
@@ -14,7 +14,7 @@ MomentsGallery is a gallery view controller inspired by Twitter's Moments. It in
   s.source           = { :git => "https://github.com/Fortyfox/MomentsGallery.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/melvinbeemer'
 
-  s.platform     = :ios, '8.2'
+  s.platform     = :ios, '8.0'
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'

--- a/Pod/Classes/MomentView.swift
+++ b/Pod/Classes/MomentView.swift
@@ -57,7 +57,14 @@ class MomentView: UIView {
         
         if moment.title != nil {
             let titleLabel = UILabel(frame: CGRectMake(25, UIScreen.mainScreen().bounds.size.height - 74, UIScreen.mainScreen().bounds.size.width - 50, 15))
-            titleLabel.font = UIFont.systemFontOfSize(13, weight: UIFontWeightSemibold)
+            
+            if #available(iOS 8.2, *) {
+                titleLabel.font = UIFont.systemFontOfSize(13, weight: UIFontWeightSemibold)
+            }
+            else {
+                titleLabel.font = UIFont.boldSystemFontOfSize(13)
+            }
+            
             titleLabel.textColor = UIColor.whiteColor()
             titleLabel.text = moment.title
             self.addSubview(titleLabel)
@@ -65,7 +72,13 @@ class MomentView: UIView {
         
         if moment.text != nil {
             let textLabel = UILabel(frame: CGRectMake(25, UIScreen.mainScreen().bounds.size.height - 55, UIScreen.mainScreen().bounds.size.width - 50, 15))
-            textLabel.font = UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)
+            if #available(iOS 8.2, *) {
+                textLabel.font = UIFont.systemFontOfSize(12, weight: UIFontWeightRegular)
+            }
+            else {
+                textLabel.font = UIFont.systemFontOfSize(12)
+            }
+            
             textLabel.textColor = UIColor.whiteColor()
             textLabel.text = moment.text
             self.addSubview(textLabel)

--- a/Pod/Classes/MomentsGallery.swift
+++ b/Pod/Classes/MomentsGallery.swift
@@ -132,7 +132,13 @@ public class MomentsGallery: UIViewController, UIScrollViewDelegate {
         // Setup close button)
         closeButton = UIButton(frame: CGRectMake(view.frame.size.width - 50, 0, 50, 50))
         closeButton?.setTitle("+", forState: .Normal)
-        closeButton?.titleLabel!.font = UIFont.systemFontOfSize(35, weight: UIFontWeightThin)
+        
+        if #available(iOS 8.2, *) {
+            closeButton?.titleLabel!.font = UIFont.systemFontOfSize(35, weight: UIFontWeightThin)
+        } else {
+            closeButton?.titleLabel!.font = UIFont.systemFontOfSize(35)
+        }
+        
         closeButton?.transform = CGAffineTransformMakeRotation(CGFloat(M_PI_4))
         closeButton?.addTarget(self, action: #selector(closeButtonTouched(_:)), forControlEvents: .TouchUpInside)
         


### PR DESCRIPTION
This pull request updates internal font definition calls with iOS 8 support. iOS 8.2 and higher keep the same version, while iOS 8 will default to bold and regular fonts (instead of Semibold and Thin).